### PR TITLE
feat: implement dependency injection with injectable package

### DIFF
--- a/lib/core/di.config.dart
+++ b/lib/core/di.config.dart
@@ -1,0 +1,60 @@
+// dart format width=80
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+
+import '../data/api/api_service.dart' as _i103;
+import '../data/repository/data_source_impl/auth_remote_data_source_impl.dart'
+    as _i32;
+import '../data/repository/repository_impl/auth_repository_impl.dart' as _i17;
+import '../domain/repository/data_source/auth_remote_data_source.dart' as _i341;
+import '../domain/repository/repository_contract/auth_repository_contract.dart'
+    as _i235;
+import '../domain/use_case/forgot_password_use_case.dart' as _i755;
+import '../domain/use_case/register_use_case.dart' as _i224;
+import '../domain/use_case/signin_use_case.dart' as _i435;
+import '../presentation/auth/login/cubit/login_screen_view_model.dart' as _i703;
+import '../presentation/forgotPassword/cubit/forgot_password_view_model.dart'
+    as _i515;
+
+extension GetItInjectableX on _i174.GetIt {
+// initializes the registration of main-scope dependencies inside of GetIt
+  _i174.GetIt init({
+    String? environment,
+    _i526.EnvironmentFilter? environmentFilter,
+  }) {
+    final gh = _i526.GetItHelper(
+      this,
+      environment,
+      environmentFilter,
+    );
+    gh.lazySingleton<_i103.ApiService>(() => _i103.ApiService());
+    gh.lazySingleton<_i341.AuthRemoteDataSource>(() =>
+        _i32.AuthRemoteDataSourceImpl(apiService: gh<_i103.ApiService>()));
+    gh.lazySingleton<_i235.AuthRepositoryContract>(() =>
+        _i17.AuthRepositoryImpl(
+            remoteDataSource: gh<_i341.AuthRemoteDataSource>()));
+    gh.factory<_i224.RegisterUseCase>(() => _i224.RegisterUseCase(
+        authRepositoryContract: gh<_i235.AuthRepositoryContract>()));
+    gh.factory<_i435.SignInUseCase>(() => _i435.SignInUseCase(
+        authRepositoryContract: gh<_i235.AuthRepositoryContract>()));
+    gh.lazySingleton<_i755.ForgotPasswordUseCase>(() =>
+        _i755.ForgotPasswordUseCase(
+            authRepositoryContract: gh<_i235.AuthRepositoryContract>()));
+    gh.factory<_i703.LoginScreenViewModel>(() =>
+        _i703.LoginScreenViewModel(signInUseCase: gh<_i435.SignInUseCase>()));
+    gh.factory<_i515.ForgotPasswordViewModel>(() =>
+        _i515.ForgotPasswordViewModel(
+            forgotPasswordUseCase: gh<_i755.ForgotPasswordUseCase>()));
+    return this;
+  }
+}

--- a/lib/core/di.dart
+++ b/lib/core/di.dart
@@ -1,32 +1,12 @@
-//todo: view model => object useCase
-//todo:  useCase => repository
-//todo:  repository => data source
-//todo:  data source => api service
+import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
+import 'di.config.dart';
+final getIt = GetIt.instance;
 
+@InjectableInit(
+  initializerName: 'init', // default
+  preferRelativeImports: true, // default
+  asExtension: true, // default
+)
+void configureDependencies() => getIt.init();
 
-import 'package:online_exam/data/api/api_service.dart';
-import 'package:online_exam/domain/use_case/register_use_case.dart';
-import 'package:online_exam/domain/use_case/signin_use_case.dart';
-
-import '../data/repository/data_source_impl/auth_remote_data_source_impl.dart';
-import '../data/repository/repository_impl/auth_repository_impl.dart';
-import '../domain/repository/data_source/auth_remote_data_source.dart';
-import '../domain/repository/repository_contract/auth_repository_contract.dart';
-import '../domain/use_case/forgot_password_use_case.dart';
-
-RegisterUseCase injectRegisterUseCase(){
-  return RegisterUseCase(authRepositoryContract: injectAuthRepositoryContract());
-}
-SignInUseCase injectSignInUseCase(){
-  return SignInUseCase(authRepositoryContract: injectAuthRepositoryContract());
-
-}
-ForgotPasswordUseCase injectForgotPasswordUseCase() {
-  return ForgotPasswordUseCase(authRepositoryContract: injectAuthRepositoryContract());
-}
-AuthRepositoryContract injectAuthRepositoryContract(){
-return AuthRepositoryImpl(remoteDataSource: injectAuthRemoteDataSource());
-}
-AuthRemoteDataSource injectAuthRemoteDataSource(){
-  return AuthRemoteDataSourceImpl(apiService: ApiService.getInstance());
-}

--- a/lib/data/api/api_service.dart
+++ b/lib/data/api/api_service.dart
@@ -14,14 +14,8 @@ import '../models/response/forgot_password_response_dto.dart';
 import 'api_constant.dart';
 import 'package:http/http.dart' as http;
 
-@singleton
+@lazySingleton
 class ApiService {
-  static ApiService? _instance;
-
-  static ApiService getInstance() {
-    _instance ??= ApiService();
-    return _instance!;
-  }
 
   //register
   Future< RegisterResult> register(

--- a/lib/data/repository/data_source_impl/auth_remote_data_source_impl.dart
+++ b/lib/data/repository/data_source_impl/auth_remote_data_source_impl.dart
@@ -1,9 +1,10 @@
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/domain/entity/auth_result_entity.dart';
 import 'package:online_exam/domain/entity/forgot_password_entity.dart';
 import '../../../domain/repository/data_source/auth_remote_data_source.dart';
 import '../../api/api_result.dart';
 import '../../api/api_service.dart';
-
+@LazySingleton(as: AuthRemoteDataSource)
 class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   final ApiService apiService;
 

--- a/lib/data/repository/repository_impl/auth_repository_impl.dart
+++ b/lib/data/repository/repository_impl/auth_repository_impl.dart
@@ -1,4 +1,5 @@
 
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/domain/entity/auth_result_entity.dart';
 import 'package:online_exam/domain/entity/forgot_password_entity.dart';
 
@@ -6,7 +7,7 @@ import 'package:online_exam/domain/entity/forgot_password_entity.dart';
 import '../../../domain/repository/data_source/auth_remote_data_source.dart';
 import '../../../domain/repository/repository_contract/auth_repository_contract.dart';
 import '../../api/api_result.dart';
-
+@LazySingleton(as: AuthRepositoryContract)
 class AuthRepositoryImpl implements AuthRepositoryContract {
   AuthRemoteDataSource remoteDataSource;
   AuthRepositoryImpl({required this.remoteDataSource});

--- a/lib/domain/use_case/forgot_password_use_case.dart
+++ b/lib/domain/use_case/forgot_password_use_case.dart
@@ -1,8 +1,9 @@
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/data/api/api_result.dart';
 import 'package:online_exam/domain/entity/forgot_password_entity.dart';
 
 import '../repository/repository_contract/auth_repository_contract.dart';
-
+@lazySingleton
 class ForgotPasswordUseCase {
   AuthRepositoryContract  authRepositoryContract;
   ForgotPasswordUseCase({required this.authRepositoryContract});

--- a/lib/domain/use_case/register_use_case.dart
+++ b/lib/domain/use_case/register_use_case.dart
@@ -1,9 +1,10 @@
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/domain/repository/repository_contract/auth_repository_contract.dart';
 
 import '../../data/api/api_result.dart';
 import '../entity/auth_result_entity.dart';
 
-
+@injectable
 class RegisterUseCase {
  AuthRepositoryContract authRepositoryContract;
  RegisterUseCase( {required this.authRepositoryContract});

--- a/lib/domain/use_case/signin_use_case.dart
+++ b/lib/domain/use_case/signin_use_case.dart
@@ -1,10 +1,11 @@
 
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/domain/repository/repository_contract/auth_repository_contract.dart';
 
 import '../../data/api/api_result.dart';
 import '../entity/auth_result_entity.dart';
 
-
+@injectable
 class SignInUseCase {
  AuthRepositoryContract authRepositoryContract;
  SignInUseCase( {required this.authRepositoryContract});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,11 @@ import 'package:online_exam/presentation/auth/register/register_screen.dart';
 
 
 import 'core/constants/app_strings.dart';
+import 'core/di.dart';
 import 'presentation/forgotPassword/forgot_password_screen.dart';
 
 void main() async {
+  configureDependencies();
   WidgetsFlutterBinding.ensureInitialized();
   const FlutterSecureStorage secureStorage = FlutterSecureStorage();
 

--- a/lib/presentation/auth/login/cubit/login_screen_view_model.dart
+++ b/lib/presentation/auth/login/cubit/login_screen_view_model.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/domain/use_case/signin_use_case.dart';
 import 'package:online_exam/presentation/auth/login/cubit/states.dart';
 
 import '../../../../data/api/api_result.dart';
-
+@injectable
 class LoginScreenViewModel extends Cubit<LoginState> {
   LoginScreenViewModel({required this.signInUseCase}) : super(SignInInitialState());
 

--- a/lib/presentation/auth/login/login_screen.dart
+++ b/lib/presentation/auth/login/login_screen.dart
@@ -19,9 +19,8 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  final LoginScreenViewModel viewModel = LoginScreenViewModel(
-    signInUseCase: injectSignInUseCase(),
-  );
+  final LoginScreenViewModel viewModel = getIt<LoginScreenViewModel>();
+
   final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
 
   bool rememberMe = false;

--- a/lib/presentation/auth/register/register_screen.dart
+++ b/lib/presentation/auth/register/register_screen.dart
@@ -17,9 +17,7 @@ class RegisterScreen extends StatefulWidget {
 }
 
 class _RegisterScreenState extends State<RegisterScreen> {
-  final RegisterScreenViewModel viewModel = RegisterScreenViewModel(
-    registerUseCase: injectRegisterUseCase(),
-  );
+  final RegisterScreenViewModel viewModel = getIt<RegisterScreenViewModel>();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/forgotPassword/cubit/forgot_password_view_model.dart
+++ b/lib/presentation/forgotPassword/cubit/forgot_password_view_model.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
 import 'package:online_exam/presentation/forgotPassword/cubit/states.dart';
 
 import '../../../data/api/api_result.dart';
 import '../../../domain/use_case/forgot_password_use_case.dart';
-
+@injectable
 class ForgotPasswordViewModel extends Cubit<ForgotState> {
   final ForgotPasswordUseCase forgotPasswordUseCase;
 

--- a/lib/presentation/forgotPassword/forgot_password_screen.dart
+++ b/lib/presentation/forgotPassword/forgot_password_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:online_exam/presentation/utlis/custome_text_form_feild.dart';
-
 import '../../core/constants/app_strings.dart';
 import '../../core/di.dart';
 import '../utlis/dialog_utlis.dart';
@@ -17,7 +16,7 @@ class ForgotPasswordScreen extends StatefulWidget {
 }
 
 class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
-final ForgotPasswordViewModel viewModel = ForgotPasswordViewModel(forgotPasswordUseCase: injectForgotPasswordUseCase());
+  final ForgotPasswordViewModel viewModel = getIt<ForgotPasswordViewModel>();
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_secure_storage: ^9.0.0
 
 
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This commit introduces the `injectable` package to manage dependency injection in the project. It includes the following changes:

-   **core/di.dart:** Added configuration for `get_it` and `injectable` to manage dependency injection.
-   **core/di.config.dart:** Generated file for dependency injection configuration, mapping dependencies to concrete implementations.
-   **data/api/api_service.dart:** Changed `ApiService` to `@lazySingleton`.
-   **data/repository/data_source_impl/auth_remote_data_source_impl.dart:** Changed `AuthRemoteDataSourceImpl` to `@LazySingleton`.
-   **data/repository/repository_impl/auth_repository_impl.dart:** Changed `AuthRepositoryImpl` to `@LazySingleton`.
-   **domain/use_case/forgot_password_use_case.dart:** Changed `ForgotPasswordUseCase` to `@lazySingleton`.
-   **domain/use_case/register_use_case.dart:** Changed `RegisterUseCase` to `@injectable`.
-   **domain/use_case/signin_use_case.dart:** Changed `SignInUseCase` to `@injectable`.
-   **presentation/auth/login/cubit/login_screen_view_model.dart:** Changed `LoginScreenViewModel` to `@injectable`.
-   **presentation/forgotPassword/cubit/forgot_password_view_model.dart:** Changed `ForgotPasswordViewModel` to `@injectable`.
-    **presentation/auth/login/login_screen.dart:** Changed to use `getIt` to inject `LoginScreenViewModel`.
-   **presentation/forgotPassword/forgot_password_screen.dart:** Changed to use `getIt` to inject `ForgotPasswordViewModel`.
- **presentation/auth/register/register_screen.dart:** Changed to use `getIt` to inject `RegisterScreenViewModel`.
- **main.dart:** add configureDependencies();
-   **pubspec.yaml:** Added `injectable` and `injectable_generator` and `build_runner` dependencies.
- removed old way to create object injection from **di.dart** .